### PR TITLE
Update BestieTemplate.jl URL to JuliaBesties

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,5 +1,5 @@
 {
   "projectName": "BestieRecommended",
-  "projectOwner": "abelsiqueira",
+  "projectOwner": "JuliaBesties",
   "files": ["README.md", "docs/src/index.md"]
 }

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -6,7 +6,7 @@ Indentation: 2
 JuliaMinVersion: '1.6'
 License: MIT
 PackageName: BestieRecommended
-PackageOwner: abelsiqueira
+PackageOwner: JuliaBesties
 PackageUUID: 49999571-eea7-54eb-9328-55f56e583ba6
 _commit: v0.8.0
-_src_path: https://github.com/abelsiqueira/BestieTemplate.jl
+_src_path: https://github.com/JuliaBesties/BestieTemplate.jl

--- a/.github/ISSUE_TEMPLATE/10-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/10-bug-report.yml
@@ -10,12 +10,12 @@ body:
 
         Please, before submitting, make sure that:
 
-        - There is not an [existing issue](https://github.com/abelsiqueira/BestieRecommended.jl/issues) with the same question
+        - There is not an [existing issue](https://github.com/JuliaBesties/BestieRecommended.jl/issues) with the same question
 
-        - You have read the [contributing guide](https://abelsiqueira.github.io/BestieRecommended.jl/dev/90-contributing/)
+        - You have read the [contributing guide](https://JuliaBesties.github.io/BestieRecommended.jl/dev/90-contributing/)
 
 
-        - You are following the [code of conduct](https://github.com/abelsiqueira/BestieRecommended.jl/blob/main/CODE_OF_CONDUCT.md)
+        - You are following the [code of conduct](https://github.com/JuliaBesties/BestieRecommended.jl/blob/main/CODE_OF_CONDUCT.md)
 
 
         The form below should help you in filling out this issue.

--- a/.github/ISSUE_TEMPLATE/20-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/20-feature-request.yml
@@ -8,12 +8,12 @@ body:
 
         Please, before submitting, make sure that:
 
-        - There is not an [existing issue](https://github.com/abelsiqueira/BestieRecommended.jl/issues) with the same question
+        - There is not an [existing issue](https://github.com/JuliaBesties/BestieRecommended.jl/issues) with the same question
 
-        - You have read the [contributing guide](https://abelsiqueira.github.io/BestieRecommended.jl/dev/90-contributing/)
+        - You have read the [contributing guide](https://JuliaBesties.github.io/BestieRecommended.jl/dev/90-contributing/)
 
 
-        - You are following the [code of conduct](https://github.com/abelsiqueira/BestieRecommended.jl/blob/main/CODE_OF_CONDUCT.md)
+        - You are following the [code of conduct](https://github.com/JuliaBesties/BestieRecommended.jl/blob/main/CODE_OF_CONDUCT.md)
 
 
         The form below should help you in filling out this issue.

--- a/.github/ISSUE_TEMPLATE/30-usage.yml
+++ b/.github/ISSUE_TEMPLATE/30-usage.yml
@@ -9,13 +9,13 @@ body:
 
         Please, before submitting, make sure that:
 
-        - You have checked the [documentation](https://abelsiqueira.github.io/BestieRecommended.jl) and haven't found enough information
-        - There is not an [existing issue](https://github.com/abelsiqueira/BestieRecommended.jl/issues) with the same question
+        - You have checked the [documentation](https://JuliaBesties.github.io/BestieRecommended.jl) and haven't found enough information
+        - There is not an [existing issue](https://github.com/JuliaBesties/BestieRecommended.jl/issues) with the same question
 
-        - You have read the [contributing guide](https://abelsiqueira.github.io/BestieRecommended.jl/dev/90-contributing/)
+        - You have read the [contributing guide](https://JuliaBesties.github.io/BestieRecommended.jl/dev/90-contributing/)
 
 
-        - You are following the [code of conduct](https://github.com/abelsiqueira/BestieRecommended.jl/blob/main/CODE_OF_CONDUCT.md)
+        - You are following the [code of conduct](https://github.com/JuliaBesties/BestieRecommended.jl/blob/main/CODE_OF_CONDUCT.md)
 
 
         The form below should help you in filling out this issue.

--- a/.github/ISSUE_TEMPLATE/99-general.yml
+++ b/.github/ISSUE_TEMPLATE/99-general.yml
@@ -8,12 +8,12 @@ body:
 
         Please, before submitting, make sure that:
 
-        - There is not an [existing issue](https://github.com/abelsiqueira/BestieRecommended.jl/issues) with the same question
+        - There is not an [existing issue](https://github.com/JuliaBesties/BestieRecommended.jl/issues) with the same question
 
-        - You have read the [contributing guide](https://abelsiqueira.github.io/BestieRecommended.jl/dev/90-contributing/)
+        - You have read the [contributing guide](https://JuliaBesties.github.io/BestieRecommended.jl/dev/90-contributing/)
 
 
-        - You are following the [code of conduct](https://github.com/abelsiqueira/BestieRecommended.jl/blob/main/CODE_OF_CONDUCT.md)
+        - You are following the [code of conduct](https://github.com/JuliaBesties/BestieRecommended.jl/blob/main/CODE_OF_CONDUCT.md)
 
 
         The form below should help you in filling out this issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discussions
-    url: https://github.com/abelsiqueira/BestieRecommended.jl/discussions
+    url: https://github.com/JuliaBesties/BestieRecommended.jl/discussions
     about: Create and follow discussions here

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@ There is no related issue.
 <!-- mark true if NA -->
 <!-- leave PR as draft until all is checked -->
 
-- [ ] I am following the [contributing guidelines](https://github.com/abelsiqueira/BestieRecommended.jl/blob/main/docs/src/90-contributing.md)
+- [ ] I am following the [contributing guidelines](https://github.com/JuliaBesties/BestieRecommended.jl/blob/main/docs/src/90-contributing.md)
 
 - [ ] Tests are passing
 - [ ] Lint workflow is passing

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # BestieRecommended
 
-[![Stable Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://abelsiqueira.github.io/BestieRecommended.jl/stable)
-[![In development documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://abelsiqueira.github.io/BestieRecommended.jl/dev)
-[![Build Status](https://github.com/abelsiqueira/BestieRecommended.jl/workflows/Test/badge.svg)](https://github.com/abelsiqueira/BestieRecommended.jl/actions)
-[![Test workflow status](https://github.com/abelsiqueira/BestieRecommended.jl/actions/workflows/Test.yml/badge.svg?branch=main)](https://github.com/abelsiqueira/BestieRecommended.jl/actions/workflows/Test.yml?query=branch%3Amain)
-[![Lint workflow Status](https://github.com/abelsiqueira/BestieRecommended.jl/actions/workflows/Lint.yml/badge.svg?branch=main)](https://github.com/abelsiqueira/BestieRecommended.jl/actions/workflows/Lint.yml?query=branch%3Amain)
-[![Docs workflow Status](https://github.com/abelsiqueira/BestieRecommended.jl/actions/workflows/Docs.yml/badge.svg?branch=main)](https://github.com/abelsiqueira/BestieRecommended.jl/actions/workflows/Docs.yml?query=branch%3Amain)
+[![Stable Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaBesties.github.io/BestieRecommended.jl/stable)
+[![In development documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaBesties.github.io/BestieRecommended.jl/dev)
+[![Build Status](https://github.com/JuliaBesties/BestieRecommended.jl/workflows/Test/badge.svg)](https://github.com/JuliaBesties/BestieRecommended.jl/actions)
+[![Test workflow status](https://github.com/JuliaBesties/BestieRecommended.jl/actions/workflows/Test.yml/badge.svg?branch=main)](https://github.com/JuliaBesties/BestieRecommended.jl/actions/workflows/Test.yml?query=branch%3Amain)
+[![Lint workflow Status](https://github.com/JuliaBesties/BestieRecommended.jl/actions/workflows/Lint.yml/badge.svg?branch=main)](https://github.com/JuliaBesties/BestieRecommended.jl/actions/workflows/Lint.yml?query=branch%3Amain)
+[![Docs workflow Status](https://github.com/JuliaBesties/BestieRecommended.jl/actions/workflows/Docs.yml/badge.svg?branch=main)](https://github.com/JuliaBesties/BestieRecommended.jl/actions/workflows/Docs.yml?query=branch%3Amain)
 
-[![Coverage](https://codecov.io/gh/abelsiqueira/BestieRecommended.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/abelsiqueira/BestieRecommended.jl)
+[![Coverage](https://codecov.io/gh/JuliaBesties/BestieRecommended.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaBesties/BestieRecommended.jl)
 [![DOI](https://zenodo.org/badge/DOI/FIXME)](https://doi.org/FIXME)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
-[![All Contributors](https://img.shields.io/github/all-contributors/abelsiqueira/BestieRecommended.jl?labelColor=5e1ec7&color=c0ffee&style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/github/all-contributors/JuliaBesties/BestieRecommended.jl?labelColor=5e1ec7&color=c0ffee&style=flat-square)](#contributors)
 
 ## How to Cite
 
-If you use BestieRecommended.jl in your work, please cite using the reference given in [CITATION.cff](https://github.com/abelsiqueira/BestieRecommended.jl/blob/main/CITATION.cff).
+If you use BestieRecommended.jl in your work, please cite using the reference given in [CITATION.cff](https://github.com/JuliaBesties/BestieRecommended.jl/blob/main/CITATION.cff).
 
 ## Contributing
 
-If you want to make contributions of any kind, please first that a look into our [contributing guide directly on GitHub](docs/src/90-contributing.md) or the [contributing page on the website](https://abelsiqueira.github.io/BestieRecommended.jl/dev/90-contributing/).
+If you want to make contributions of any kind, please first that a look into our [contributing guide directly on GitHub](docs/src/90-contributing.md) or the [contributing page on the website](https://JuliaBesties.github.io/BestieRecommended.jl/dev/90-contributing/).
 
 ---
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,11 +18,11 @@ makedocs(;
   doctest = true,
   linkcheck = false, # Rely on Lint.yml/lychee for the links
   authors = "Abel Soares Siqueira <abel.s.siqueira@gmail.com> and contributors",
-  repo = "https://github.com/abelsiqueira/BestieRecommended.jl/blob/{commit}{path}#{line}",
+  repo = "https://github.com/JuliaBesties/BestieRecommended.jl/blob/{commit}{path}#{line}",
   sitename = "BestieRecommended.jl",
   format = Documenter.HTML(;
     prettyurls = true,
-    canonical = "https://abelsiqueira.github.io/BestieRecommended.jl",
+    canonical = "https://JuliaBesties.github.io/BestieRecommended.jl",
     assets = ["assets/style.css"],
   ),
   pages = [
@@ -34,4 +34,4 @@ makedocs(;
   ],
 )
 
-deploydocs(; repo = "github.com/abelsiqueira/BestieRecommended.jl", push_preview = true)
+deploydocs(; repo = "github.com/JuliaBesties/BestieRecommended.jl", push_preview = true)

--- a/docs/src/90-contributing.md
+++ b/docs/src/90-contributing.md
@@ -8,7 +8,7 @@ Be polite and respectful, and follow the code of conduct.
 
 ## Bug reports and discussions
 
-If you think you found a bug, feel free to open an [issue](https://github.com/abelsiqueira/BestieRecommended.jl/issues).
+If you think you found a bug, feel free to open an [issue](https://github.com/JuliaBesties/BestieRecommended.jl/issues).
 Focused suggestions and requests can also be opened as issues.
 Before opening a pull request, start an issue or a discussion on the topic, please.
 

--- a/docs/src/91-developer.md
+++ b/docs/src/91-developer.md
@@ -17,7 +17,7 @@ If this is the first time you work with this repository, follow the instructions
 3. Add this repo as a remote:
 
    ```bash
-   git remote add upstream https://github.com/abelsiqueira/BestieRecommended.jl
+   git remote add upstream https://github.com/JuliaBesties/BestieRecommended.jl
    ```
 
 This will ensure that you have two remotes in your git: `origin` and `upstream`.
@@ -149,7 +149,7 @@ To create a new release, you can follow these simple steps:
   - Add a new link in the bottom for version "x.y.z"
   - Change the "[unreleased]" link to use the latest version - end of line, `vx.y.z ... HEAD`.
 - Create a commit "Release vx.y.z", push, create a PR, wait for it to pass, merge the PR.
-- Go back to main screen and click on the latest commit (link: <https://github.com/abelsiqueira/BestieRecommended.jl/commit/main>)
+- Go back to main screen and click on the latest commit (link: <https://github.com/JuliaBesties/BestieRecommended.jl/commit/main>)
 - At the bottom, write `@JuliaRegistrator register`
 
 After that, you only need to wait and verify:
@@ -157,7 +157,7 @@ After that, you only need to wait and verify:
 - Wait for the bot to comment (should take < 1m) with a link to a RP to the registry
 - Follow the link and wait for a comment on the auto-merge
 - The comment should said all is well and auto-merge should occur shortly
-- After the merge happens, TagBot will trigger and create a new GitHub tag. Check on <https://github.com/abelsiqueira/BestieRecommended.jl/releases>
+- After the merge happens, TagBot will trigger and create a new GitHub tag. Check on <https://github.com/JuliaBesties/BestieRecommended.jl/releases>
 - After the release is create, a "docs" GitHub action will start for the tag.
 - After it passes, a deploy action will run.
-- After that runs, the [stable docs](https://abelsiqueira.github.io/BestieRecommended.jl/stable) should be updated. Check them and look for the version number.
+- After that runs, the [stable docs](https://JuliaBesties.github.io/BestieRecommended.jl/stable) should be updated. Check them and look for the version number.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@ CurrentModule = BestieRecommended
 
 # BestieRecommended
 
-Documentation for [BestieRecommended](https://github.com/abelsiqueira/BestieRecommended.jl).
+Documentation for [BestieRecommended](https://github.com/JuliaBesties/BestieRecommended.jl).
 
 ## Contributors
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -2,7 +2,7 @@ exclude = [
   "@ref",
   "^https://github.com/.*/releases/tag/v.*$",
   "^https://doi.org/FIXME$",
-  "^https://abelsiqueira.github.io/BestieRecommended.jl/stable$",
+  "^https://JuliaBesties.github.io/BestieRecommended.jl/stable$",
   "zenodo.org/badge/DOI/FIXME$"
 ]
 


### PR DESCRIPTION
This is a semi-automated PR.
BestieTemplate.jl has been moved to the JuliaBesties organization.
This updates the URL in .copier-answers.yml to point to the new location.
